### PR TITLE
Expose the predicate value when calling getComponents function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jena ARQ Compound Naming Property Functions Library
 
-A library of functions for working with data in the Compound Naming structure. See the [Compound Naming Model](https://agldwg.github.io/compound-naming-model/model.html) for more information.
+A library of functions for working with data in the Compound Name structure. See the [Compound Naming Model](https://agldwg.github.io/compound-naming-model/model.html) for more information.
 
 ## Example code usage
 
@@ -8,14 +8,14 @@ This repo contains a [Main.kt](src/main/kotlin/Main.kt) that loads in [src/main/
 
 We can run the following SPARQL query which utilises the `getComponents` property function. This function recursively fetches all the component parts of the compound name instance and returns its type, the value and the component identifier.
 
-Where component identifiers are blank nodes, the internal Jena system identifier is returned. This can be used in tandem with RDF Delta Patch logs to provide updates to blank node instances.
+Where component identifiers are blank nodes, the internal Jena system identifier is returned. This can be used in tandem with RDF Delta Patch logs to provide updates to blank node objects.
 
 ```sparql
 SELECT *
 WHERE {
     GRAPH ?g {
         BIND(<https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> AS ?iri)
-        ?iri <java:ai.kurrawong.jena.compoundnaming.getComponents> (?componentType ?componentValue ?componentId) .
+        ?iri <java:ai.kurrawong.jena.compoundnaming.getComponents> (?componentId ?componentType ?componentValuePredicate ?componentValue) .
     }
 }
 limit 10
@@ -24,18 +24,18 @@ limit 10
 And get the following result.
 
 ```
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-| iri                                                            | componentType                                                                 | componentValue  | componentId                                                            | g                   |
-===================================================================================================================================================================================================================================================================
-| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/flatTypeCode>  | "U"             | "<https://example.com/flatTypeCode/U>"                                 | <urn:graph:address> |
-| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | <https://linked.data.gov.au/def/roads/ct/RoadType>                            | "HWY (Y)"       | "_:e28c67b9f6971165cc8b9baf15e9be01"                                   | <urn:graph:address> |
-| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/flatNumber>    | "14"            | "_:1a6454c0258fb72a999604b64c9d36a3"                                   | <urn:graph:address> |
-| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/locality>      | "MERMAID BEACH" | "<https://linked.data.gov.au/dataset/qld-addr/locality-MERMAID-BEACH>" | <urn:graph:address> |
-| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/numberFirst>   | "2342"          | "_:7ffd45b7bf489525c34c62e48f8cdc7a"                                   | <urn:graph:address> |
-| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/levelTypeCode> | "G"             | "<https://linked.data.gov.au/dataset/gnaf/code/levelType/G>"           | <urn:graph:address> |
-| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/numberLast>    | "2358"          | "_:976136004ffaa60901d4429608366808"                                   | <urn:graph:address> |
-| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | <https://linked.data.gov.au/def/roads/ct/RoadName>                            | "Gold Coast"    | "_:1ba3a39c7c1d53e1a8ab145852ec3db3"                                   | <urn:graph:address> |
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+| iri                                                            | componentId                                                            | componentType                                                                 | componentValuePredicate                            | componentValue  | g                   |
+========================================================================================================================================================================================================================================================================================================================
+| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | "_:Bfda6114ad800c1af0288290785e39a6d"                                  | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/numberFirst>   | <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> | "2342"          | <urn:graph:address> |
+| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | "_:Beabaa5eb2b97d6c462bad07a6f93c3a7"                                  | <https://linked.data.gov.au/def/roads/ct/RoadType>                            | <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> | "HWY (Y)"       | <urn:graph:address> |
+| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | "<https://linked.data.gov.au/dataset/qld-addr/locality-MERMAID-BEACH>" | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/locality>      | <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> | "MERMAID BEACH" | <urn:graph:address> |
+| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | "_:B6b29dbbe6752d412e5b6b49b22155f40"                                  | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/numberLast>    | <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> | "2358"          | <urn:graph:address> |
+| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | "<https://linked.data.gov.au/dataset/gnaf/code/levelType/G>"           | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/levelTypeCode> | <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> | "G"             | <urn:graph:address> |
+| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | "_:Bbafed18729ee5b64b2d70c7a1571a12a"                                  | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/flatNumber>    | <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> | "14"            | <urn:graph:address> |
+| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | "<https://example.com/flatTypeCode/U>"                                 | <https://w3id.org/profile/anz-address/AnzAddressComponentTypes/flatTypeCode>  | <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> | "U"             | <urn:graph:address> |
+| <https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> | "_:Bca1972342d0c18281993925563061a18"                                  | <https://linked.data.gov.au/def/roads/ct/RoadName>                            | <http://www.w3.org/1999/02/22-rdf-syntax-ns#value> | "Gold Coast"    | <urn:graph:address> |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
 ## Build

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -1,5 +1,6 @@
-/* Example usage
-* */
+/**
+ * Example usage.
+ */
 import ai.kurrawong.jena.compoundnaming.GetComponentsPropertyFunctionFactory
 
 import org.apache.jena.query.*
@@ -38,22 +39,11 @@ SELECT *
 WHERE {
     GRAPH ?g {
         BIND(<https://linked.data.gov.au/dataset/qld-addr/addr-obj-1837741> AS ?iri)
-        ?iri <java:ai.kurrawong.jena.compoundnaming.getComponents> (?componentType ?componentValue ?componentId) .
+        ?iri <java:ai.kurrawong.jena.compoundnaming.getComponents> (?componentId ?componentType ?componentValuePredicate ?componentValue) .
     }
 }
 limit 10
             """.trimIndent()
-
-//    val queryString = """
-//PREFIX func: <https://linked.data.gov.au/def/cn/func/>
-//
-//SELECT *
-//WHERE {
-//    BIND(<https://linked.data.gov.au/dataset/qld-addr/addr-obj-33254> AS ?iri)
-//    ?iri func:getLiteralComponents (?componentType ?componentValue ?componentId) .
-//}
-//limit 10
-//            """.trimIndent()
 
     val query = QueryFactory.create(queryString)
 
@@ -61,15 +51,4 @@ limit 10
         val results = qexec.execSelect()
         ResultSetFormatter.out(System.out, results, query)
     }
-
-//    val query2 = QueryFactory.create(
-//        """
-//        DESCRIBE <https://linked.data.gov.au/dataset/qld-addr/addr-1075435>
-//    """.trimIndent()
-//    )
-//
-//    QueryExecutionFactory.create(query2, dataset).use { queryExecution ->
-//        val results = queryExecution.execDescribe()
-//        results.write(System.out, "TURTLE")
-//    }
 }

--- a/src/main/kotlin/ai/kurrawong/jena/compoundnaming/Binding5.kt
+++ b/src/main/kotlin/ai/kurrawong/jena/compoundnaming/Binding5.kt
@@ -1,0 +1,117 @@
+package ai.kurrawong.jena.compoundnaming
+
+import org.apache.jena.graph.Node
+import org.apache.jena.sparql.core.Var
+import org.apache.jena.sparql.engine.binding.Binding
+import org.apache.jena.sparql.engine.binding.BindingBase
+import java.util.*
+import java.util.function.BiConsumer
+
+/**
+ * A binding implementation that supports 5 binding pairs.
+ */
+class Binding5 (
+    parent: Binding?,
+    var1: Var,
+    value1: Node,
+    var2: Var,
+    value2: Node,
+    var3: Var,
+    value3: Node,
+    var4: Var,
+    value4: Node,
+    var5: Var,
+    value5: Node
+) : BindingBase(parent) {
+    private val var1: Var = Objects.requireNonNull(var1)
+    private val value1: Node = Objects.requireNonNull(value1)
+
+    private val var2: Var = Objects.requireNonNull(var2)
+    private val value2: Node = Objects.requireNonNull(value2)
+
+    private val var3: Var = Objects.requireNonNull(var3)
+    private val value3: Node = Objects.requireNonNull(value3)
+
+    private val var4: Var = Objects.requireNonNull(var4)
+    private val value4: Node = Objects.requireNonNull(value4)
+
+    private val var5: Var = Objects.requireNonNull(var5)
+    private val value5: Node = Objects.requireNonNull(value5)
+
+    override fun vars1(): Iterator<Var> {
+        return Itr.iter5(var1, var2, var3, var4, var5)
+    }
+
+    override fun forEach1(action: BiConsumer<Var, Node>) {
+        action.accept(var1, value1)
+        action.accept(var2, value2)
+        action.accept(var3, value3)
+        action.accept(var4, value4)
+        action.accept(var5, value5)
+    }
+
+
+    protected fun getVar1(idx: Int): Var? {
+        if (idx == 0) return var1
+        if (idx == 1) return var2
+        if (idx == 2) return var3
+        if (idx == 3) return var4
+        if (idx == 4) return var5
+        return null
+    }
+
+    override fun size1(): Int {
+        if (var1 == null) return 0
+        if (var2 == null) return 1
+        if (var3 == null) return 2
+        if (var4 == null) return 3
+        if (var5 == null) return 4
+        return 5
+    }
+
+    override fun isEmpty1(): Boolean {
+        return var1 == null
+    }
+
+    override fun contains1(`var`: Var): Boolean {
+        if (`var` == null) return false
+
+        if (var1 == null) return false
+        if (`var` == var1) return true
+
+        if (var2 == null) return false
+        if (`var` == var2) return true
+
+        if (var3 == null) return false
+        if (`var` == var3) return true
+
+        if (var4 == null) return false
+        if (`var` == var4) return true
+
+        if (var5 == null) return false
+        if (`var` == var5) return true
+
+        return false
+    }
+
+    override fun get1(`var`: Var): Node? {
+        if (`var` == null) return null
+
+        if (var1 == null) return null
+        if (`var` == var1) return value1
+
+        if (var2 == null) return null
+        if (`var` == var2) return value2
+
+        if (var3 == null) return null
+        if (`var` == var3) return value3
+
+        if (var4 == null) return null
+        if (`var` == var4) return value4
+
+        if (var5 == null) return null
+        if (`var` == var5) return value5
+
+        return null
+    }
+}

--- a/src/main/kotlin/ai/kurrawong/jena/compoundnaming/CompoundNaming.kt
+++ b/src/main/kotlin/ai/kurrawong/jena/compoundnaming/CompoundNaming.kt
@@ -2,9 +2,19 @@ package ai.kurrawong.jena.compoundnaming
 
 import org.apache.jena.graph.Graph
 import org.apache.jena.graph.Node
+import java.io.Serializable
+
+/**
+ * Represents a 4-tuple.
+ *
+ * Same as a Pair or a Triple in Kotlin stdlib but for 4 values.
+ */
+data class Quadruple<A,B,C,D>(var first: A, var second: B, var third: C, var fourth: D): Serializable {
+    override fun toString(): String = "($first, $second, $third, $fourth)"
+}
 
 class CompoundName(private val graph: Graph, private var componentQueue: List<Node>) {
-    val data = mutableSetOf<Triple<Node, Node, Node>>()
+    val data = mutableSetOf<Quadruple<Node, Node, Node, Node>>()
 
     init {
         while (componentQueue.isNotEmpty()) {
@@ -20,7 +30,14 @@ class CompoundName(private val graph: Graph, private var componentQueue: List<No
         }
     }
 
-    private fun getComponentLiteral(focusNode: Node): Triple<Node, Node, Node> {
+    /**
+     * Return a Quadruple data structure containing:
+     * - first - the component identifier - an IRI or internal system identifier as a blank node
+     * - second - the component type - an IRI
+     * - third - the component's predicate which contains the value
+     * - fourth - the component's value
+     */
+    private fun getComponentLiteral(focusNode: Node): Quadruple<Node, Node, Node, Node> {
         val result = graph.find(focusNode, hasValue, Node.ANY).toList()
         var sdoNames = graph.find(focusNode, sdoName, Node.ANY).toList().map { triple -> triple.`object` }
         var hasParts = graph.find(focusNode, hasPart, Node.ANY).toList().map { triple -> triple.`object` }
@@ -59,6 +76,6 @@ class CompoundName(private val graph: Graph, private var componentQueue: List<No
             throw Exception("Focus node $focusNode does not have a component type.")
         }
 
-        return Triple(componentTypes[0].`object`, value.`object`, value.subject)
+        return Quadruple(value.subject, componentTypes[0].`object`,  value.predicate, value.`object`)
     }
 }

--- a/src/main/kotlin/ai/kurrawong/jena/compoundnaming/GetComponentsPropertyFunctionFactory.kt
+++ b/src/main/kotlin/ai/kurrawong/jena/compoundnaming/GetComponentsPropertyFunctionFactory.kt
@@ -3,6 +3,9 @@ package ai.kurrawong.jena.compoundnaming
 import org.apache.jena.sparql.pfunction.PropertyFunction
 import org.apache.jena.sparql.pfunction.PropertyFunctionFactory
 
+/**
+ * Factory to register getComponents SPARQL property function in Jena.
+ */
 class GetComponentsPropertyFunctionFactory : PropertyFunctionFactory {
     override fun create(uri: String): PropertyFunction {
         return getComponents()

--- a/src/main/kotlin/ai/kurrawong/jena/compoundnaming/Itr.kt
+++ b/src/main/kotlin/ai/kurrawong/jena/compoundnaming/Itr.kt
@@ -1,0 +1,152 @@
+package ai.kurrawong.jena.compoundnaming
+
+
+import java.util.*
+
+/** Iterator of 0 objects  */
+class Itr0<X> : Iterator<X> {
+    override fun hasNext(): Boolean {
+        return false
+    }
+
+    override fun next(): X {
+        throw NoSuchElementException()
+    }
+
+    companion object {
+        // Same as Iter.nullIterator but named for tracking and development usage.
+        var NULL: Itr0<*> = Itr0<Any>()
+        fun <T> itr0(): Itr0<*> {
+            return Itr0.Companion.NULL
+        }
+    }
+}
+
+/** Iterator of 1 objects  */
+class Itr1<X>(x1: X) : Iterator<X> {
+    private var idx = 0
+    private val elt1: X = Objects.requireNonNull(x1)
+
+    override fun hasNext(): Boolean {
+        return idx < 1
+    }
+
+    override fun next(): X {
+        idx++
+        if (idx == 1) return elt1
+        throw NoSuchElementException()
+    }
+}
+
+/** Iterator of 2 objects  */
+class Itr2<X>(x1: X, x2: X) : Iterator<X> {
+    private var idx = 0
+    private val elt1: X = Objects.requireNonNull(x1)
+    private val elt2: X = Objects.requireNonNull(x2)
+
+    override fun hasNext(): Boolean {
+        return idx < 2
+    }
+
+    override fun next(): X {
+        idx++
+        if (idx == 1) return elt1
+        if (idx == 2) return elt2
+        throw NoSuchElementException()
+    }
+}
+
+/** Iterator of 3 objects  */
+class Itr3<X>(x1: X, x2: X, x3: X) : Iterator<X> {
+    private var idx = 0
+    private val elt1: X = Objects.requireNonNull(x1)
+    private val elt2: X = Objects.requireNonNull(x2)
+    private val elt3: X = Objects.requireNonNull(x3)
+
+    override fun hasNext(): Boolean {
+        return idx < 3
+    }
+
+    override fun next(): X {
+        idx++
+        if (idx == 1) return elt1
+        if (idx == 2) return elt2
+        if (idx == 3) return elt3
+        throw NoSuchElementException()
+    }
+}
+
+/** Iterator of 4 objects  */
+class Itr4<X>(x1: X, x2: X, x3: X, x4: X) : Iterator<X> {
+    private var idx = 0
+    private val elt1: X = Objects.requireNonNull(x1)
+    private val elt2: X = Objects.requireNonNull(x2)
+    private val elt3: X = Objects.requireNonNull(x3)
+    private val elt4: X = Objects.requireNonNull(x4)
+
+    override fun hasNext(): Boolean {
+        return idx < 4
+    }
+
+    override fun next(): X {
+        idx++
+        if (idx == 1) return elt1
+        if (idx == 2) return elt2
+        if (idx == 3) return elt3
+        if (idx == 4) return elt4
+        throw NoSuchElementException()
+    }
+}
+
+/** Iterator of 5 objects  */
+class Itr5<X>(x1: X, x2: X, x3: X, x4: X, x5: X) : Iterator<X> {
+    private var idx = 0
+    private val elt1: X = Objects.requireNonNull(x1)
+    private val elt2: X = Objects.requireNonNull(x2)
+    private val elt3: X = Objects.requireNonNull(x3)
+    private val elt4: X = Objects.requireNonNull(x4)
+    private val elt5: X = Objects.requireNonNull(x5)
+
+    override fun hasNext(): Boolean {
+        return idx < 5
+    }
+
+    override fun next(): X {
+        idx++
+        if (idx == 1) return elt1
+        if (idx == 2) return elt2
+        if (idx == 3) return elt3
+        if (idx == 4) return elt4
+        if (idx == 5) return elt5
+        throw NoSuchElementException()
+    }
+}
+
+/**
+ * Emulates the Itr class with static iterN methods from Jena.
+ */
+object Itr {
+    fun <X> iter0(): Iterator<X> {
+        return Itr0()
+    }
+
+    fun <X> iter1(x1: X): Iterator<X> {
+        return Itr1(x1)
+    }
+
+    fun <X> iter2(x1: X, x2: X): Iterator<X> {
+        return Itr2(x1, x2)
+    }
+
+    fun <X> iter3(x1: X, x2: X, x3: X): Iterator<X> {
+        return Itr3(x1, x2, x3)
+    }
+
+    fun <X> iter4(x1: X, x2: X, x3: X, x4: X): Iterator<X> {
+        return Itr4(x1, x2, x3, x4)
+    }
+
+    fun <X> iter5(x1: X, x2: X, x3: X, x4: X, x5: X): Iterator<X> {
+        return Itr5(x1, x2, x3, x4, x5)
+    }
+}


### PR DESCRIPTION
Add a fifth return value for getComponents property function. This fifth value contains the predicate that links the value of a component.